### PR TITLE
Mention vanity import path in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ vcsstore stores VCS repositories and makes them accessible via HTTP.
 ## Install
 
 * Install libssh2 and libssl-dev: `apt-get install libssh2-1-dev libssl-dev`
+* Run `go get -d -u sourcegraph.com/sourcegraph/vcsstore` and cd into the folder
 * Run `make build-libgit2`
 * `godep go install ./cmd/vcsstore`
 * `vcsstore serve`


### PR DESCRIPTION
- Since the import path is not simply the github remote, it should be mentioned in README.
- I added `-d` flag to prevent `go get` from trying to install the package ahead of time, since the following steps are responsible for that.
