### PR TITLE
Middleware support

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -1,0 +1,17 @@
+package server
+
+import "net/http"
+
+type Middleware func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc)
+
+func FuncWithMiddleware(h http.HandlerFunc, mw ...Middleware) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if len(mw) >= 2 {
+			mw[0](w, r, FuncWithMiddleware(h, mw[1:]...))
+		} else if len(mw) == 1 {
+			mw[0](w, r, h)
+		} else if len(mw) == 0 {
+			h(w, r)
+		}
+	}
+}


### PR DESCRIPTION
This makes it possible to inject middleware when creating a vcsstore server from `server.NewHandler`. The signature of `server.NewHandler` is backwards compatible since the middleware is a variadic argument.

The first use case of this would be adding in an appdash middleware.