### PR TITLE
Make go generate directives work on more setups.

### DIFF
--- a/vcsclient/gen.go
+++ b/vcsclient/gen.go
@@ -1,4 +1,4 @@
 package vcsclient
 
-//go:generate protoc -I../../../.. -I../../../../github.com/gogo/protobuf/protobuf -I. --gogo_out=. vcsclient.proto
-//go:generate sed -i "s#\tTreeEntryType_#\t#g" vcsclient.pb.go
+//go:generate gopathexec protoc -I$GOPATH/src -I$GOPATH/src/github.com/gogo/protobuf/protobuf -I. --gogo_out=. vcsclient.proto
+//go:generate go run gen/goreplace.go -from "TreeEntryType_" -to "" vcsclient.pb.go

--- a/vcsclient/gen/goreplace.go
+++ b/vcsclient/gen/goreplace.go
@@ -1,0 +1,49 @@
+// +build generate
+
+// Command goreplace replaces all instances of "from" string with "to" string in specified files.
+// Like basic string replacement functionality of sed, but works on OS X, Linux and Windows.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func main() {
+	var fromFlag = flag.String("from", "", "source string to replace")
+	var toFlag = flag.String("to", "", "string to replace with")
+	flag.Parse()
+
+	files := flag.Args()
+	if len(files) == 0 {
+		log.Fatalln("no files to process")
+	}
+
+	for _, path := range files {
+		fmt.Fprintln(os.Stderr, "#", path)
+		err := processFile(path, *fromFlag, *toFlag)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+}
+
+func processFile(path, from, to string) error {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	b = bytes.Replace(b, []byte(from), []byte(to), -1)
+
+	err = ioutil.WriteFile(path, b, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add support for running go generate successfully on OS X.

Add support for running go generate with multiple GOPATH workspaces.

Similar change to sourcegraph/go-sourcegraph#49, sourcegraph/go-vcs#67 and https://github.com/sourcegraph/srclib/pull/177.