### PR TITLE
Recursion limit

### DIFF
--- a/vcsclient/fs.go
+++ b/vcsclient/fs.go
@@ -211,7 +211,20 @@ func readDir(fs vfs.FileSystem, base string, recurseSingleSubfolder bool, first 
 	te := make([]*TreeEntry, len(entries))
 	for i, fi := range entries {
 		te[i] = newTreeEntry(fi)
-		if fi.Mode().IsDir() && recurseSingleSubfolder {
+	}
+
+	if recurseSingleSubfolder {
+		dirEntries := make(map[int]os.FileInfo)
+		for i, fi := range entries {
+			if len(dirEntries) > 20 { // expand at most 20 subdirectories
+				break
+			}
+
+			if fi.Mode().IsDir() {
+				dirEntries[i] = fi
+			}
+		}
+		for i, fi := range dirEntries {
 			ee, err := readDir(fs, path.Join(base, fi.Name()), recurseSingleSubfolder, false)
 			if err != nil {
 				return nil, err
@@ -219,6 +232,7 @@ func readDir(fs vfs.FileSystem, base string, recurseSingleSubfolder bool, first 
 			te[i].Entries = ee
 		}
 	}
+
 	return te, nil
 }
 

--- a/vcsclient/fs.go
+++ b/vcsclient/fs.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sync"
 
 	"sort"
 
@@ -210,18 +211,32 @@ func readDir(fs vfs.FileSystem, base string, recurseSingleSubfolderLimit int, fi
 	if recurseSingleSubfolderLimit > 0 && !first && !singleSubDir(entries) {
 		return nil, nil
 	}
-	te := make([]*TreeEntry, len(entries))
-	dirCount := 0
+	var (
+		wg         sync.WaitGroup
+		recurseErr error
+		dirCount   = 0
+		te         = make([]*TreeEntry, len(entries))
+	)
 	for i, fi := range entries {
 		te[i] = newTreeEntry(fi)
 		if fi.Mode().IsDir() && dirCount < recurseSingleSubfolderLimit {
 			dirCount++
-			ee, err := readDir(fs, path.Join(base, fi.Name()), recurseSingleSubfolderLimit, false)
-			if err != nil {
-				return nil, err
-			}
-			te[i].Entries = ee
+			i, name := i, fi.Name()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ee, err := readDir(fs, path.Join(base, name), recurseSingleSubfolderLimit, false)
+				if err != nil {
+					recurseErr = err
+					return
+				}
+				te[i].Entries = ee
+			}()
 		}
+	}
+	wg.Wait()
+	if recurseErr != nil {
+		return nil, recurseErr
 	}
 	return te, nil
 }

--- a/vcsclient/fs.go
+++ b/vcsclient/fs.go
@@ -209,23 +209,11 @@ func readDir(fs vfs.FileSystem, base string, recurseSingleSubfolder int, first b
 		return nil, nil
 	}
 	te := make([]*TreeEntry, len(entries))
+	dirCount := 0
 	for i, fi := range entries {
 		te[i] = newTreeEntry(fi)
-	}
-
-	if recurseSingleSubfolder > 0 {
-		dirEntries := make(map[int]os.FileInfo)
-		for i, fi := range entries {
-			// expand at most recurseSingleSubfolder subdirectories
-			if len(dirEntries) > recurseSingleSubfolder {
-				break
-			}
-
-			if fi.Mode().IsDir() {
-				dirEntries[i] = fi
-			}
-		}
-		for i, fi := range dirEntries {
+		if fi.Mode().IsDir() && dirCount < recurseSingleSubfolder {
+			dirCount++
 			ee, err := readDir(fs, path.Join(base, fi.Name()), recurseSingleSubfolder, false)
 			if err != nil {
 				return nil, err
@@ -233,7 +221,6 @@ func readDir(fs vfs.FileSystem, base string, recurseSingleSubfolder int, first b
 			te[i].Entries = ee
 		}
 	}
-
 	return te, nil
 }
 

--- a/vcsclient/fs_test.go
+++ b/vcsclient/fs_test.go
@@ -343,7 +343,7 @@ func TestGetFileWithOptions_recurseSingleSubfolder(t *testing.T) {
 		},
 	}
 
-	e, err := GetFileWithOptions(testGetFileWithOptionsFS, "/", GetFileOptions{RecurseSingleSubfolder: true})
+	e, err := GetFileWithOptions(testGetFileWithOptionsFS, "/", GetFileOptions{RecurseSingleSubfolder: 9999})
 	if err != nil {
 		t.Errorf("GetFileWithOptions returned error: %v", err)
 	}

--- a/vcsclient/fs_test.go
+++ b/vcsclient/fs_test.go
@@ -343,7 +343,7 @@ func TestGetFileWithOptions_recurseSingleSubfolder(t *testing.T) {
 		},
 	}
 
-	e, err := GetFileWithOptions(testGetFileWithOptionsFS, "/", GetFileOptions{RecurseSingleSubfolder: 9999})
+	e, err := GetFileWithOptions(testGetFileWithOptionsFS, "/", GetFileOptions{RecurseSingleSubfolderLimit: 9999})
 	if err != nil {
 		t.Errorf("GetFileWithOptions returned error: %v", err)
 	}

--- a/vcsclient/vcsclient.pb.go
+++ b/vcsclient/vcsclient.pb.go
@@ -83,8 +83,9 @@ type GetFileOptions struct {
 	// sub-directories.
 	Recursive bool `protobuf:"varint,5,opt,name=recursive,proto3" json:"recursive,omitempty" url:",omitempty"`
 	// RecurseSingleSubfolder only applies if the returned entry is a directory.
-	// It will recursively find and include all sub-directories with a single sub-directory.
-	RecurseSingleSubfolder bool `protobuf:"varint,6,opt,name=recurse_single_subfolder,proto3" json:"recurse_single_subfolder,omitempty" url:",omitempty"`
+	// If nonzero, it will recursively find and include all singleton sub-directory chains,
+	// up to a limit of RecurseSingleSubfolder.
+	RecurseSingleSubfolder int32 `protobuf:"varint,6,opt,name=recurse_single_subfolder,proto3" json:"recurse_single_subfolder,omitempty" url:",omitempty"`
 }
 
 func (m *GetFileOptions) Reset()         { *m = GetFileOptions{} }

--- a/vcsclient/vcsclient.pb.go
+++ b/vcsclient/vcsclient.pb.go
@@ -82,10 +82,10 @@ type GetFileOptions struct {
 	// return the full file tree of the host repository, recursing into all
 	// sub-directories.
 	Recursive bool `protobuf:"varint,5,opt,name=recursive,proto3" json:"recursive,omitempty" url:",omitempty"`
-	// RecurseSingleSubfolder only applies if the returned entry is a directory.
+	// RecurseSingleSubfolderLimit only applies if the returned entry is a directory.
 	// If nonzero, it will recursively find and include all singleton sub-directory chains,
-	// up to a limit of RecurseSingleSubfolder.
-	RecurseSingleSubfolder int32 `protobuf:"varint,6,opt,name=recurse_single_subfolder,proto3" json:"recurse_single_subfolder,omitempty" url:",omitempty"`
+	// up to a limit of RecurseSingleSubfolderLimit.
+	RecurseSingleSubfolderLimit int32 `protobuf:"varint,6,opt,name=recurse_single_subfolder_limit,proto3" json:"recurse_single_subfolder_limit,omitempty" url:",omitempty"`
 }
 
 func (m *GetFileOptions) Reset()         { *m = GetFileOptions{} }

--- a/vcsclient/vcsclient.proto
+++ b/vcsclient/vcsclient.proto
@@ -44,10 +44,10 @@ message GetFileOptions {
 	// sub-directories.
 	bool recursive = 5 [(gogoproto.moretags) = "url:\",omitempty\""];
 
-	// RecurseSingleSubfolder only applies if the returned entry is a directory.
+	// RecurseSingleSubfolderLimit only applies if the returned entry is a directory.
 	// If nonzero, it will recursively find and include all singleton sub-directory chains,
-	// up to a limit of RecurseSingleSubfolder.
-	int32 recurse_single_subfolder = 6 [(gogoproto.moretags) = "url:\",omitempty\""];
+	// up to a limit of RecurseSingleSubfolderLimit.
+	int32 recurse_single_subfolder_limit = 6 [(gogoproto.moretags) = "url:\",omitempty\""];
 }
 
 enum TreeEntryType {

--- a/vcsclient/vcsclient.proto
+++ b/vcsclient/vcsclient.proto
@@ -45,8 +45,9 @@ message GetFileOptions {
 	bool recursive = 5 [(gogoproto.moretags) = "url:\",omitempty\""];
 
 	// RecurseSingleSubfolder only applies if the returned entry is a directory.
-	// It will recursively find and include all sub-directories with a single sub-directory.
-	bool recurse_single_subfolder = 6 [(gogoproto.moretags) = "url:\",omitempty\""];
+	// If nonzero, it will recursively find and include all singleton sub-directory chains,
+	// up to a limit of RecurseSingleSubfolder.
+	int32 recurse_single_subfolder = 6 [(gogoproto.moretags) = "url:\",omitempty\""];
 }
 
 enum TreeEntryType {


### PR DESCRIPTION
This makes `RecurseSingleSubfolder` an int instead of a bool, making the number of subdirectories searched for single-sub-directory chains limited to a number (as this can become computationally expensive).