### PR TITLE
Make ComputeFileRange return error on inverted byte/line ranges

### DIFF
--- a/vcsclient/range.go
+++ b/vcsclient/range.go
@@ -45,6 +45,10 @@ func ComputeFileRange(data []byte, opt GetFileOptions) (*FileRange, *fileset.Fil
 		if fr.EndLine < 0 {
 			return nil, nil, fmt.Errorf("end line %d out of bounds (%d lines total)", fr.EndLine, f.LineCount())
 		}
+		if fr.StartLine > fr.EndLine {
+			return nil, nil, fmt.Errorf("start line (%d) cannot be greater than end line (%d) (%d lines total)", fr.StartLine, fr.EndLine, f.LineCount())
+		}
+
 		if count := int64(f.LineCount()); fr.EndLine > count || fr.EndLine == 0 {
 			fr.EndLine = count
 		}
@@ -55,6 +59,9 @@ func ComputeFileRange(data []byte, opt GetFileOptions) (*FileRange, *fileset.Fil
 		}
 		if fr.EndByte < 0 || fr.EndByte > int64(len(data)) {
 			return nil, nil, fmt.Errorf("end byte %d out of bounds (%d bytes total)", fr.EndByte, len(data))
+		}
+		if fr.StartByte > fr.EndByte {
+			return nil, nil, fmt.Errorf("start byte (%d) cannot be greater than end byte (%d) (%d bytes total)", fr.StartByte, fr.EndByte, len(data))
 		}
 
 		fr.StartLine, fr.EndLine = int64(f.Line(f.Pos(int(fr.StartByte)))), int64(f.Line(f.Pos(int(fr.EndByte))))

--- a/vcsclient/range_test.go
+++ b/vcsclient/range_test.go
@@ -48,6 +48,11 @@ func TestComputeFileRange(t *testing.T) {
 			opt:  GetFileOptions{FileRange: FileRange{StartLine: 2, EndLine: 2}},
 			want: FileRange{StartLine: 2, EndLine: 2, StartByte: 2, EndByte: 4},
 		},
+		"OOB end line": {
+			data: []byte("a\nb"),
+			opt:  GetFileOptions{FileRange: FileRange{StartLine: 0, EndLine: 999999}},
+			want: FileRange{StartLine: 2, EndLine: 2, StartByte: 2, EndByte: 4},
+		},
 	}
 	for label, test := range tests {
 		got, _, err := ComputeFileRange(test.data, test.opt)

--- a/vcsclient/range_test.go
+++ b/vcsclient/range_test.go
@@ -69,3 +69,65 @@ func TestComputeFileRange(t *testing.T) {
 		_ = test.data[got.StartByte:got.EndByte]
 	}
 }
+
+func TestComputeBadFileRange(t *testing.T) {
+	tests := map[string]struct {
+		data []byte
+		opt  GetFileOptions
+		want string
+	}{
+		// Byte ranges
+		"negative start byte": {
+			data: []byte("a\nb\n"),
+			opt:  GetFileOptions{FileRange: FileRange{StartByte: -1, EndByte: 3}},
+			want: "start byte -1 out of bounds (4 bytes total)",
+		},
+		"OOB end byte": {
+			data: []byte("a\nb\n"),
+			opt:  GetFileOptions{FileRange: FileRange{StartByte: 0, EndByte: 5}},
+			want: "end byte 5 out of bounds (4 bytes total)",
+		},
+		"inverse valid bytes": {
+			data: []byte("a\nb\n"),
+			opt:  GetFileOptions{FileRange: FileRange{StartByte: 3, EndByte: 0}},
+			want: "start byte (3) cannot be greater than end byte (0) (4 bytes total)",
+		},
+		"inverse 2 lines, byte range": {
+			data: []byte("a\nb\n"),
+			opt:  GetFileOptions{FileRange: FileRange{StartByte: 3, EndByte: 2}},
+			want: "start byte (3) cannot be greater than end byte (2) (4 bytes total)",
+		},
+		"inverse 2 lines, byte range, full lines": {
+			data: []byte("a\nb\n"),
+			opt:  GetFileOptions{FileRange: FileRange{StartByte: 3, EndByte: 2}, FullLines: true},
+			want: "start byte (3) cannot be greater than end byte (2) (4 bytes total)",
+		},
+
+		// Line ranges
+		"negative start line": {
+			data: []byte("a\nb"),
+			opt:  GetFileOptions{FileRange: FileRange{StartLine: -1, EndLine: 1}},
+			want: "start line -1 out of bounds (2 lines total)",
+		},
+		"inverse 2 lines, no trailing newline": {
+			data: []byte("a\nb"),
+			opt:  GetFileOptions{FileRange: FileRange{StartLine: 2, EndLine: 1}},
+			want: "start line (2) cannot be greater than end line (1) (2 lines total)",
+		},
+		"inverse 2 lines, trailing newline": {
+			data: []byte("a\nb\n"),
+			opt:  GetFileOptions{FileRange: FileRange{StartLine: 2, EndLine: 1}},
+			want: "start line (2) cannot be greater than end line (1) (2 lines total)",
+		},
+	}
+	for label, test := range tests {
+		got, _, err := ComputeFileRange(test.data, test.opt)
+		if err == nil || err.Error() != test.want {
+			t.Errorf("%s: got %q, want %q", label, err, test.want)
+			continue
+		}
+		if got != nil {
+			t.Errorf("%s: expected nil result", label)
+		}
+	}
+}

--- a/vcsclient/range_test.go
+++ b/vcsclient/range_test.go
@@ -51,7 +51,7 @@ func TestComputeFileRange(t *testing.T) {
 		"OOB end line": {
 			data: []byte("a\nb"),
 			opt:  GetFileOptions{FileRange: FileRange{StartLine: 0, EndLine: 999999}},
-			want: FileRange{StartLine: 2, EndLine: 2, StartByte: 2, EndByte: 4},
+			want: FileRange{StartLine: 1, EndLine: 2, StartByte: 0, EndByte: 3},
 		},
 	}
 	for label, test := range tests {

--- a/vcsclient/range_test.go
+++ b/vcsclient/range_test.go
@@ -64,5 +64,8 @@ func TestComputeFileRange(t *testing.T) {
 		if *got != test.want {
 			t.Errorf("%s: got %+v, want %+v", label, *got, test.want)
 		}
+
+		// Validate indices against data.
+		_ = test.data[got.StartByte:got.EndByte]
 	}
 }


### PR DESCRIPTION
This change fixes a panic where the returned byte ranges are invalid as the user passed lines or byte ranges that are in bounds (greater than zero, less than `len(data)`) but are inverted (e.g. `data[4:2]` instead of `data[2:4]`). This fixes a panic we were seeing in prod.

Also add many tests to improve catching these sort of cases in the future / avoid regressions.